### PR TITLE
Add configure_capture & Update start & stop capture scripts

### DIFF
--- a/start_capture.py
+++ b/start_capture.py
@@ -204,9 +204,8 @@ def parse_args(argv):
     parser.add_argument(
         "--configure_readout",
         "-conf",
-        type=bool,
-        default=False,
         required=False,
+        action="store_true",
         help="Configures the readout settings if specified. If disabled, just starts readout.",
     )
     return parser.parse_args(argv)

--- a/start_capture.py
+++ b/start_capture.py
@@ -43,27 +43,27 @@ def main():
     brd = Board(board_model)
     brd.get_udp_connection(board_ip, host_ip)
 
-    # Readout configuration, uncomment if you want to configure right before start readout
-    # if args.trigger_values:
-    #     get_trigger_controller(brd).values = args.trigger_values
+    if args.configure_readout:
+        if args.trigger_values:
+            get_trigger_controller(brd).values = args.trigger_values
+            get_trigger_controller(brd).write_triggers()
+        
+        if args.dac_values:
+            for chan, val in enumerate(args.dac_values):
+                get_dac_controller(brd).set_single_dac(chan, val)
 
-    # if args.dac_values:
-    #     for chan, val in enumerate(args.dac_values):
-    #         get_dac_controller(brd).set_single_dac(chan, val)
+        if args.trigger_refs:
+            if len(args.trigger_refs) != 4:
+                raise ValueError("Trigger references must include 4 values: low_l high_l low_r high_r")
+            low_l, high_l, low_r, high_r = args.trigger_refs
+            refs = {
+                "left": (low_l, high_l),
+                "right": (low_r, high_r),
+            }
+            get_trigger_controller(brd).references = refs
 
-    # if args.trigger_refs:
-    #     if len(args.trigger_refs) != 4:
-    #         raise ValueError("Trigger references must include 4 values: low_l high_l low_r high_r")
-    #     low_l, high_l, low_r, high_r = args.trigger_refs
-    #     refs = {
-    #         "left": (low_l, high_l),
-    #         "right": (low_r, high_r),
-    #     }
-    #     get_trigger_controller(brd).references = refs
-
-    # get_readout_controller(brd).set_read_window(*args.readout_window)
-    # get_readout_controller(brd).set_readout_channels([*range(32)])
-    # get_trigger_controller(brd).write_triggers()
+        get_readout_controller(brd).set_read_window(*args.readout_window)
+        get_readout_controller(brd).set_readout_channels([*range(brd.channels)])
 
     # Set receiver address to the target computer's address
     brd.connection_info["receiver_addr"] = target_ip
@@ -200,6 +200,14 @@ def parse_args(argv):
         help="Trigger reference values: low_l high_l low_r high_r",
         nargs=4,
         metavar=("LOW_L", "HIGH_L", "LOW_R", "HIGH_R"),
+    )
+    parser.add_argument(
+        "--configure_readout",
+        "-conf",
+        type=bool,
+        default=False,
+        required=False,
+        help="Configures the readout settings if specified. If disabled, just starts readout.",
     )
     return parser.parse_args(argv)
 

--- a/stop_capture.py
+++ b/stop_capture.py
@@ -6,6 +6,7 @@ import sys
 from helpers import _is_ip_valid, _is_port_valid
 from naluconfigs import get_available_models
 from naludaq.board import Board
+from naludaq.communication import ControlRegisters
 from naludaq.controllers import get_board_controller
 
 
@@ -28,6 +29,8 @@ def main():
     brd = Board(board_model)
     brd.get_udp_connection(board_ip, host_ip)
 
+    current_registers = ControlRegisters(brd).read_addr_named("04")
+    brd.registers["control_registers"].update(current_registers)
     get_board_controller(brd).stop_readout()
 
     brd.disconnect()


### PR DESCRIPTION
Added set_readout_channels command to the board readout configuration (start_readout & configure_readout).
Add configure_capture.py just for modifying the readout settings of the board (trigger values, read window, dac, etc.).

Updated start_capture to give an option to disable or enable the configuration of the readout settings.
Updated stop_capture to ensure the board does not overwrite values on the same address when writing the command that is run during stop_readout().
